### PR TITLE
Make sure 'WindowProcedure' signature exactly matches WNDPROC declaration.

### DIFF
--- a/src/screenmqtt.cpp
+++ b/src/screenmqtt.cpp
@@ -616,7 +616,7 @@ void update_monitors() {
     connect_monitors();
 }
 
-long __stdcall WindowProcedure(HWND window, unsigned int msg, WPARAM wp, LPARAM lp)
+LRESULT CALLBACK WindowProcedure(HWND window, unsigned int msg, WPARAM wp, LPARAM lp)
 {
     switch (msg)
     {


### PR DESCRIPTION
This fixes compilation in visual studio 2019 for me.