### PR TITLE
When reconnecting after a connection loss, also resubscribe to previously subscribed topics.

### DIFF
--- a/src/msgqueue.h
+++ b/src/msgqueue.h
@@ -31,6 +31,7 @@ struct MessageQueueOptions {
 class MessageQueue {
 protected:
     MQTTClient client = nullptr;
+    std::vector<std::pair<std::string, MessageQueueOptions>> subscriptions;
 
     int backoff_cur = 0;
 


### PR DESCRIPTION
Without this we'll stop responding to commands after a reconnect.